### PR TITLE
update script not to use credentials file

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2016


### PR DESCRIPTION
### why this update needed

When using awscli with aws-vault, there are no .aws/credentials file.
aws-profile command not depend to credentials file.
